### PR TITLE
Fix some internal links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Loomio Technical Manual
 
 ## Installing Loomio
-[Setup a Loomio development environment](https://github.com/loomio/loomio/wiki/setup_development_environment) on MacOS X or Ubuntu Linux. There is a [screencast](https://www.youtube.com/watch?v=YOjQFM9S4Rg) available to guide you through this part of the process.
+[Setup a Loomio development environment](setup_development_environment.md) on MacOS X or Ubuntu Linux. There is a [screencast](https://www.youtube.com/watch?v=YOjQFM9S4Rg) available to guide you through this part of the process.
 
-[Setup a Loomio production environment](https://github.com/loomio/loomio/wiki/setup_loomio_production) (Almost complete, looking for feedback) How to setup Loomio just like we do, to run Loomio.org.
+[Setup a Loomio production environment](setup_loomio_production.md) (Almost complete, looking for feedback) How to setup Loomio just like we do, to run Loomio.org.
 
 *Need some help?* Check out the [Installing Loomio](https://www.loomio.org/g/C7I2YAPN/loomio-community-installing-loomio) group.  
 
@@ -13,10 +13,10 @@ Loomio is Ruby, Coffeescript, HTML/CSS and Love! Feel free to throw any of those
  
 #### Translate Loomio
 We have an active translation community. Check out 
-[the Translation guide](https://github.com/loomio/loomio/wiki/Translation).
+[the Translation guide](translation.md).
 
 #### Help develop the software
-If you'd like to contribute to the project, [Setup your development environment](https://github.com/loomio/loomio/wiki/setup_development_environment) and read up on our [Development Process](https://github.com/loomio/loomio/wiki/2-Development-process).
+If you'd like to contribute to the project, [Setup your development environment](setup_development_environment.md) and read up on our [Development Process](using_development.md).
 
 #### Report a bug
 To report a bug, please open a [new Github Issue](https://github.com/loomio/loomio/issues/new)

--- a/setup_loomio_production.md
+++ b/setup_loomio_production.md
@@ -4,12 +4,15 @@ If you decide to use [Digital Ocean](http://www.digitalocean.com) as your VPS ho
 
 This guide assumes that you have a little bit of experience using ssh, git and linux and can provision your own VPS or server. I've also assumed that you have a domain name for your Loomio install figured out. Something like `loomio.myexistingdomainname.com` will be fine. Good luck, and I hope that you find everything straight forward. If you have problems the appropriate place to ask for help is the [installing Loomio group](https://www.loomio.org/g/C7I2YAPN/loomio-community-installing-loomio) in the Loomio Community. You can expect that setting up Loomio will take 2 to 4 hours to complete.
 
-1. [Basic VPS setup](https://github.com/loomio/loomio/wiki/Basic-VPS-setup)
-2. [Setup Loomio with Dokku](https://github.com/loomio/loomio/wiki/Install-Dokku)
-3. [Setup reply by email](https://github.com/loomio/loomio/wiki/Setup-reply-by-email)
-4. [File upload, single sign on, addressbook integration](https://github.com/loomio/loomio/wiki/File-upload,-Facebook-and-Google-integrations)
-5. [Database backup](https://github.com/loomio/loomio/wiki/postgres-backup-with-wal-e)
+1. [Basic VPS setup](basic_vps_setup.md)
+1. [Setup Loomio with Dokku](install_loomio_with_dokku.md)
+1. [Environment Variables](environment_variables.md)
+1. [Setup PostgreSQL](setup_postgresql.md)
+1. [Setup SMTP server](setup_smtp_server.md)
 
-Optionally:
-- [Setup a firewall] (https://github.com/loomio/loomio/wiki/Setup-a-firewall)
-- [Setup SSL](https://github.com/loomio/loomio/wiki/Setup-SSL)
+Optionally:  
+- [Setup realtime messaging](setup_faye.md)
+- [Setup reply by email](setup_reply_by_email.md)
+- [Setup third party integrations](setup_loomio_integrations.md)
+- [Setup Slack integration](setup_slack.md)
+- [Setup SSL/TLS](setup_ssl.md)


### PR DESCRIPTION
It probably makes sense to also disable the [apparently outdated wiki](https://github.com/loomio/loomio/wiki), or replace it with links to the User and Tech manuals (which could be more prominent in the README as well).